### PR TITLE
Add execution statistics tracking and migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           go build -race
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.1.6
 
       - name: install  goveralls
         run: go install github.com/mattn/goveralls@latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,78 +1,82 @@
-linters-settings:
-  govet:
-    shadow: true
-  gocyclo:
-    min-complexity: 15
-  maligned:
-    suggest-new: true
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-
+version: "2"
+run:
+  concurrency: 4
 linters:
+  default: none
   enable:
-    - staticcheck
-    - revive
-    - govet
-    - unconvert
-    - gosec
-    - unparam
-    - typecheck
-    - ineffassign
-    - stylecheck
-    - gochecknoinits
-    - copyloopvar
-    - gocritic
-    - nakedret
-    - gosimple
-    - prealloc
-    - unused
     - contextcheck
     - copyloopvar
     - decorder
     - errorlint
     - exptostd
     - gochecknoglobals
-    - gofmt
-    - goimports
+    - gochecknoinits
+    - gocritic
+    - gosec
+    - govet
+    - ineffassign
+    - nakedret
     - nilerr
+    - prealloc
     - predeclared
+    - revive
+    - staticcheck
     - testifylint
     - thelper
-  fast: false
-  disable-all: true
-
-
-run:
-  concurrency: 4
-
-issues:
-  exclude-rules:
-    - text: "G114: Use of net/http serve function that has no support for setting timeouts"
-      linters:
-        - gosec
-    - linters:
-        - unparam
-        - revive
-      path: _test\.go$
-      text: "unused-parameter"
-    - linters:
-        - prealloc
-      path: _test\.go$
-      text: "Consider pre-allocating"
-    - linters:
-        - gosec
-        - intrange
-      path: _test\.go$
-  exclude-use-default: false
+    - unconvert
+    - unparam
+    - unused
+    - nestif
+    - wrapcheck
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable-all: true
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - gosec
+        text: 'G114: Use of net/http serve function that has no support for setting timeouts'
+      - linters:
+          - revive
+          - unparam
+        path: _test\.go$
+        text: unused-parameter
+      - linters:
+          - prealloc
+        path: _test\.go$
+        text: Consider pre-allocating
+      - linters:
+          - gosec
+          - intrange
+        path: _test\.go$
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/repeater.go
+++ b/repeater.go
@@ -14,9 +14,25 @@ import (
 // makes it fail on any error from the function
 var ErrAny = errors.New("any error")
 
-// Repeater holds configuration for retry operations
+// Stats holds execution statistics for a repeater run
+type Stats struct {
+	LastError     error         // Last error encountered (nil if succeeded)
+	StartedAt     time.Time     // When the repeater started
+	FinishedAt    time.Time     // When the repeater finished
+	TotalDuration time.Duration // Total elapsed time from start to finish
+	WorkDuration  time.Duration // Time spent executing the function (excluding delays)
+	DelayDuration time.Duration // Time spent in delays between attempts
+	Attempts      int           // Number of attempts made (including the successful one)
+	Success       bool          // Whether the operation eventually succeeded
+}
+
+// Repeater holds configuration for retry operations.
+// Note: Repeater is not thread-safe. Each Repeater instance should not be used
+// concurrently for different functions. Create separate Repeater instances for
+// concurrent operations.
 type Repeater struct {
 	strategy Strategy
+	stats    Stats
 	attempts int
 }
 
@@ -54,6 +70,11 @@ func NewFixed(attempts int, delay time.Duration) *Repeater {
 func (r *Repeater) Do(ctx context.Context, fun func() error, termErrs ...error) error {
 	var lastErr error
 
+	// reset and initialize stats
+	r.stats = Stats{
+		StartedAt: time.Now(),
+	}
+
 	inErrors := func(err error) bool {
 		for _, e := range termErrs {
 			if errors.Is(e, ErrAny) {
@@ -69,16 +90,32 @@ func (r *Repeater) Do(ctx context.Context, fun func() error, termErrs ...error) 
 	for attempt := 0; attempt < r.attempts; attempt++ {
 		// check context before each attempt
 		if err := ctx.Err(); err != nil {
-			return err
+			r.stats.Attempts = attempt
+			r.stats.LastError = err
+			r.stats.FinishedAt = time.Now()
+			r.stats.TotalDuration = r.stats.FinishedAt.Sub(r.stats.StartedAt)
+			return err //nolint:wrapcheck // context errors are standard and don't need wrapping
 		}
 
+		workStart := time.Now()
 		var err error
 		if err = fun(); err == nil {
+			r.stats.Attempts = attempt + 1
+			r.stats.Success = true
+			r.stats.WorkDuration += time.Since(workStart)
+			r.stats.FinishedAt = time.Now()
+			r.stats.TotalDuration = r.stats.FinishedAt.Sub(r.stats.StartedAt)
 			return nil
 		}
 
+		r.stats.WorkDuration += time.Since(workStart)
+
 		lastErr = err
 		if inErrors(err) {
+			r.stats.Attempts = attempt + 1
+			r.stats.LastError = err
+			r.stats.FinishedAt = time.Now()
+			r.stats.TotalDuration = r.stats.FinishedAt.Sub(r.stats.StartedAt)
 			return err
 		}
 
@@ -86,14 +123,31 @@ func (r *Repeater) Do(ctx context.Context, fun func() error, termErrs ...error) 
 		if attempt < r.attempts-1 {
 			delay := r.strategy.NextDelay(attempt + 1)
 			if delay > 0 {
+				delayStart := time.Now()
 				select {
 				case <-ctx.Done():
-					return ctx.Err()
+					r.stats.Attempts = attempt + 1
+					r.stats.LastError = ctx.Err()
+					r.stats.DelayDuration += time.Since(delayStart)
+					r.stats.FinishedAt = time.Now()
+					r.stats.TotalDuration = r.stats.FinishedAt.Sub(r.stats.StartedAt)
+					return ctx.Err() //nolint:wrapcheck // context errors are standard and don't need wrapping
 				case <-time.After(delay):
+					r.stats.DelayDuration += time.Since(delayStart)
 				}
 			}
 		}
 	}
 
+	r.stats.Attempts = r.attempts
+	r.stats.LastError = lastErr
+	r.stats.FinishedAt = time.Now()
+	r.stats.TotalDuration = r.stats.FinishedAt.Sub(r.stats.StartedAt)
+
 	return lastErr
+}
+
+// Stats returns the execution statistics from the last Do() call
+func (r *Repeater) Stats() Stats {
+	return r.stats
 }


### PR DESCRIPTION
## Summary
- Added execution statistics tracking to the repeater package
- Migrated golangci-lint configuration to v2 format
- Updated GitHub Actions workflow

## Changes

### New Features
- **Stats() method**: Track execution metrics including:
  - Number of attempts made
  - Success/failure status
  - Total duration, work duration, and delay duration
  - Last error encountered
  - Start and finish timestamps
- Comprehensive test coverage for statistics tracking
- Updated README with detailed statistics documentation

### Technical Updates
- Migrated `.golangci.yml` to v2 format
- Updated GitHub Actions to use `golangci-lint-action@v7` with version `v2.1.6`
- Fixed all linting issues:
  - Field alignment optimizations
  - Updated test assertions to follow testifylint recommendations
  - Added nolint comments for context error returns
- Added thread-safety documentation

## Testing
- All existing tests pass
- Added comprehensive test suite for statistics tracking
- golangci-lint v2 runs clean with no issues